### PR TITLE
Edge function scraping fixes, CI triggers, remove Lovable meta tags

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,7 @@
 name: Integration Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, develop ]
   pull_request:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'cursor/**' ]
   pull_request:
     branches: [ main ]
   schedule:

--- a/index.html
+++ b/index.html
@@ -5,16 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>amex krisflyer hilton voucher lookup</title>
     <meta name="description" content="AMEX Krisflyer credit card holders receive a voucher for a free night stay at Hilton every year. There are restrictions, so you need to check one hotel and day at a time, at https://apac.hilton.com/amexkrisflyer. Use this website to check all days for which the voucher is valid in one shot!">
-    <meta name="author" content="Lovable" />
-
-    <meta property="og:title" content="kris-flyer-room-finder" />
-    <meta property="og:description" content="Lovable Generated Project" />
+    <meta property="og:title" content="AMEX KrisFlyer Hilton voucher lookup" />
+    <meta property="og:description" content="Check Hilton voucher availability across your stay dates." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:card" content="summary" />
   </head>
 
   <body>

--- a/supabase/functions/check-hotel-availability/index.ts
+++ b/supabase/functions/check-hotel-availability/index.ts
@@ -1,6 +1,28 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { addDaysYmd } from "../_shared/hilton-dates.ts";
+
+/** Parse YYYY-MM-DD as local calendar date (not UTC). */
+function parseYmdLocal(ymd: string): Date {
+  const parts = ymd.split("-").map((x) => parseInt(x, 10));
+  const y = parts[0];
+  const m = parts[1];
+  const d = parts[2];
+  if (!y || !m || !d) throw new Error(`Invalid date: ${ymd}`);
+  return new Date(y, m - 1, d);
+}
+
+function formatYmdLocal(d: Date): string {
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${mo}-${day}`;
+}
+
+function addDaysYmd(ymd: string, days: number): string {
+  const dt = parseYmdLocal(ymd);
+  dt.setDate(dt.getDate() + days);
+  return formatYmdLocal(dt);
+}
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
 const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
@@ -408,7 +430,14 @@ async function checkWithBrowserlessFunction(
         await page.waitForFunction(
           () => {
             const t = document.body && document.body.innerText ? document.body.innerText : '';
-            return /krisflyer|voucher|unavailable|rooms?\\b/i.test(t) && t.length > 400;
+            const u = t.toLowerCase();
+            return (
+              t.length > 400 &&
+              (u.includes('krisflyer') ||
+                u.includes('voucher') ||
+                u.includes('unavailable') ||
+                u.includes('room'))
+            );
           },
           { timeout: 25000 },
         );

--- a/supabase/functions/fetch-hotel-data/index.ts
+++ b/supabase/functions/fetch-hotel-data/index.ts
@@ -6,6 +6,39 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+const AMEX_LANDING = 'https://apac.hilton.com/amexkrisflyer';
+
+async function fetchHtmlViaBrowserless(url: string, token: string): Promise<string> {
+  const browserlessUrl =
+    `https://production-sfo.browserless.io/function?token=${encodeURIComponent(token)}&stealth=true`;
+  const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '');
+  const script = `
+    module.exports = async ({ page }) => {
+      await page.setViewport({ width: 1280, height: 900 });
+      await page.setExtraHTTPHeaders({ 'Accept-Language': 'en-US,en;q=0.9' });
+      await page.goto('${esc(url)}', { waitUntil: 'networkidle2', timeout: 90000 });
+      await new Promise((r) => setTimeout(r, 5000));
+      const html = await page.content();
+      return { html };
+    };
+  `;
+  const res = await fetch(browserlessUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/javascript' },
+    body: script,
+  });
+  if (!res.ok) {
+    const t = await res.text();
+    throw new Error(`Browserless fetch-hotel-data failed: ${res.status} ${t}`);
+  }
+  const data = await res.json();
+  if (typeof data === 'string') return data;
+  if (data && typeof (data as { html?: string }).html === 'string') {
+    return (data as { html: string }).html;
+  }
+  throw new Error('Browserless returned unexpected payload');
+}
+
 serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
@@ -66,59 +99,74 @@ serve(async (req) => {
 
     // If we get here, either no cache exists or it's stale - refresh the data
     console.log('Refreshing hotel data from source...');
-    
+
     const scraperApiKey = Deno.env.get('SCRAPERAPI_KEY');
-    if (!scraperApiKey) {
-      console.error('SCRAPERAPI_KEY environment variable not found');
-      throw new Error('SCRAPERAPI_KEY is not configured');
+    const browserlessToken = Deno.env.get('BROWSERLESS_API_KEY');
+    if (!scraperApiKey && !browserlessToken) {
+      throw new Error('SCRAPERAPI_KEY and/or BROWSERLESS_API_KEY must be configured');
     }
 
-    const verificationUrl = 'https://apac.hilton.com/amexkrisflyer';
-    const params = new URLSearchParams({
-      'api_key': scraperApiKey,
-      'url': verificationUrl,
-      'render': 'true',
-      'country_code': 'sg',
-      'session_number': '1',
-      'wait': '3000',
-      'premium': 'true'
-    });
+    let htmlContent = '';
 
-    const scraperUrl = `https://api.scraperapi.com/?${params.toString()}`;
-    const response = await fetch(scraperUrl, {
-      method: 'GET',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    if (scraperApiKey) {
+      const params = new URLSearchParams({
+        'api_key': scraperApiKey,
+        'url': AMEX_LANDING,
+        'render': 'true',
+        'country_code': 'sg',
+        'session_number': '1',
+        'wait': '8000',
+        'premium': 'true',
+      });
+      const scraperUrl = `https://api.scraperapi.com/?${params.toString()}`;
+      const response = await fetch(scraperUrl, {
+        method: 'GET',
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        },
+      });
+      console.log('ScraperAPI response status:', response.status);
+      if (response.ok) {
+        htmlContent = await response.text();
+      } else {
+        const errorText = await response.text();
+        console.error('ScraperAPI error response:', errorText);
       }
-    });
+    }
 
-    console.log('ScraperAPI response status:', response.status);
+    if ((!htmlContent || htmlContent.length < 1000) && browserlessToken) {
+      console.log('ScraperAPI HTML weak or missing; trying Browserless for hotel list...');
+      try {
+        htmlContent = await fetchHtmlViaBrowserless(AMEX_LANDING, browserlessToken);
+        console.log('Browserless HTML length:', htmlContent.length);
+      } catch (e) {
+        console.error('Browserless fetch failed:', e?.message ?? e);
+      }
+    }
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error('ScraperAPI error response:', errorText);
-      
-      // If scraping fails but we have cached data, return stale cache
+    if (!htmlContent) {
       if (cachedData) {
-        console.log('Scraping failed, returning stale cached data as fallback');
-        return new Response(JSON.stringify({
-          ...cachedData.data,
-          cached: true,
-          stale: true,
-          lastUpdated: cachedData.last_updated,
-          warning: 'Using cached data due to scraping failure'
-        }), {
-          headers: { 
-            ...corsHeaders,
-            'Content-Type': 'application/json'
+        console.log('No HTML from providers, returning stale cached data');
+        return new Response(
+          JSON.stringify({
+            ...cachedData.data,
+            cached: true,
+            stale: true,
+            lastUpdated: cachedData.last_updated,
+            warning: 'Using cached data due to scraping failure',
+          }),
+          {
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json',
+            },
           },
-        });
+        );
       }
-      
-      throw new Error(`ScraperAPI failed with status ${response.status}: ${errorText}`);
+      throw new Error('Failed to fetch hotel list HTML from ScraperAPI and Browserless');
     }
 
-    const htmlContent = await response.text();
     console.log('HTML content received, length:', htmlContent.length);
     
     if (!htmlContent || htmlContent.length < 1000) {

--- a/supabase/functions/validate-voucher/index.ts
+++ b/supabase/functions/validate-voucher/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
 interface VoucherValidationRequest {
@@ -15,435 +15,412 @@ interface VoucherValidationResult {
   error?: string;
 }
 
-// Helper function to validate voucher details using REAL ScraperAPI validation
-async function validateVoucher(creditCard: string, voucherCode: string): Promise<VoucherValidationResult> {
-  console.log('Real voucher validation for:', { creditCard, voucherCode });
-  
-  const scraperApiKey = Deno.env.get('SCRAPERAPI_KEY');
-  if (!scraperApiKey) {
+const BASE_URL = "https://apac.hilton.com/amexkrisflyer";
+
+const USED_VOUCHER_MSG = "You've used your voucher code. Please provide another one.";
+const INCORRECT_ENTRY_MSG = "You've provided an incorrect entry. Please try again.";
+
+function parseVoucherOutcome(html: string): VoucherValidationResult | null {
+  if (html.includes(USED_VOUCHER_MSG)) {
+    return { valid: false, error: USED_VOUCHER_MSG };
+  }
+  if (html.includes(INCORRECT_ENTRY_MSG)) {
     return {
       valid: false,
-      error: 'SCRAPERAPI_KEY not configured. Please set your ScraperAPI key in the environment variables.'
+      error:
+        "We couldn't verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.",
     };
   }
-  
-  // Basic format validation first
+  if (html.includes('data-validation-result="INVALID"')) {
+    const msgMatch = html.match(/data-validation-message="([^"]+)"/);
+    if (msgMatch) {
+      return { valid: false, error: msgMatch[1].replace(/&quot;/g, '"') };
+    }
+    return {
+      valid: false,
+      error:
+        "We couldn't verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.",
+    };
+  }
+  if (html.includes('data-validation-result="VALID"')) {
+    return { valid: true };
+  }
+  return null;
+}
+
+async function validateWithBrowserless(
+  creditCard: string,
+  voucherCode: string,
+  token: string,
+): Promise<VoucherValidationResult> {
+  const browserlessUrl =
+    `https://production-sfo.browserless.io/function?token=${encodeURIComponent(token)}&stealth=true`;
+
+  const esc = (s: string) =>
+    s.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\n/g, "");
+
+  const puppeteerScript = `
+    module.exports = async ({ page }) => {
+      await page.setViewport({ width: 1280, height: 900 });
+      await page.setExtraHTTPHeaders({
+        'Accept-Language': 'en-US,en;q=0.9',
+      });
+      await page.goto('${esc(BASE_URL)}', { waitUntil: 'networkidle2', timeout: 90000 });
+      await new Promise((r) => setTimeout(r, 2000));
+
+      const cardSelectors = [
+        'input[name="bin_number"]',
+        '#bin_number',
+        'input[autocomplete="cc-number"]',
+        'input[inputmode="numeric"]',
+      ];
+      const voucherSelectors = [
+        'input[name="voucher_no"]',
+        '#voucher_no',
+        'input[name="voucher"]',
+      ];
+
+      let binInput = null;
+      let voucherInput = null;
+      for (const sel of cardSelectors) {
+        binInput = await page.$(sel);
+        if (binInput) break;
+      }
+      for (const sel of voucherSelectors) {
+        voucherInput = await page.$(sel);
+        if (voucherInput) break;
+      }
+
+      if (!binInput || !voucherInput) {
+        throw new Error('Voucher form inputs not found');
+      }
+
+      await binInput.click({ clickCount: 3 });
+      await binInput.type('${esc(creditCard)}', { delay: 45 });
+
+      await voucherInput.click({ clickCount: 3 });
+      await voucherInput.type('${esc(voucherCode)}', { delay: 45 });
+
+      const submit =
+        (await page.$('button[type="submit"]')) ||
+        (await page.$('input[type="submit"]'));
+      const btns = await page.$$('button');
+      let clickTarget = submit;
+      if (!clickTarget && btns.length) {
+        for (const b of btns) {
+          const t = await page.evaluate((el) => (el.textContent || '').trim().toLowerCase(), b);
+          if (t === 'submit' || t.includes('submit')) {
+            clickTarget = b;
+            break;
+          }
+        }
+      }
+      if (clickTarget) await clickTarget.click();
+
+      try {
+        await page.waitForFunction(
+          () => {
+            const h = document.body ? document.body.innerHTML : '';
+            const txt = document.body ? document.body.innerText : '';
+            return (
+              h.indexOf("You've used your voucher") !== -1 ||
+              h.indexOf("You've provided an incorrect entry") !== -1 ||
+              h.indexOf('aria-invalid="true"') !== -1 ||
+              /select a destination|choose your hotel|amex kfa/i.test(txt)
+            );
+          },
+          { timeout: 35000 },
+        );
+      } catch (_) {
+        /* use whatever loaded */
+      }
+
+      await new Promise((r) => setTimeout(r, 1500));
+      const html = await page.content();
+      const innerText = await page.evaluate(() => (document.body ? document.body.innerText : ''));
+      return { html, innerText };
+    };
+  `;
+
+  const response = await fetch(browserlessUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/javascript" },
+    body: puppeteerScript,
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`Browserless failed: ${response.status} ${err}`);
+  }
+
+  const payload = await response.json();
+  const html = typeof payload?.html === "string" ? payload.html : "";
+  const innerText = typeof payload?.innerText === "string" ? payload.innerText : "";
+  const combined = innerText.length > html.length / 5 ? `${innerText}\n${html}` : html;
+
+  const fromMarkers = parseVoucherOutcome(combined);
+  if (fromMarkers) return fromMarkers;
+
+  if (combined.includes(USED_VOUCHER_MSG)) {
+    return { valid: false, error: USED_VOUCHER_MSG };
+  }
+  if (combined.includes(INCORRECT_ENTRY_MSG)) {
+    return {
+      valid: false,
+      error:
+        "We couldn't verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.",
+    };
+  }
+
+  const lowered = combined.toLowerCase();
+  if (
+    lowered.includes("aria-invalid") &&
+    (lowered.includes("true") || combined.includes('aria-invalid="true"'))
+  ) {
+    return {
+      valid: false,
+      error:
+        "We couldn't verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.",
+    };
+  }
+
+  if (/select\s+a\s+destination|choose\s+your\s+hotel|amex\s+kfa/i.test(combined)) {
+    return { valid: true };
+  }
+
+  throw new Error("Browserless: could not determine voucher outcome");
+}
+
+function buildScraperCustomJs(creditCard: string, voucherCode: string): string {
+  const escJs = (s: string) =>
+    s.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\r|\n/g, "");
+
+  return `
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const USED = "You've used your voucher code. Please provide another one.";
+  const BAD = "You've provided an incorrect entry. Please try again.";
+  await sleep(1200);
+
+  const cardSelectors = ['input[name="bin_number"]', '#bin_number', 'input[autocomplete="cc-number"]', 'input[inputmode="numeric"]'];
+  const voucherSelectors = ['input[name="voucher_no"]', '#voucher_no', 'input[name="voucher"]'];
+
+  let binInput = null;
+  let voucherInput = null;
+  for (const sel of cardSelectors) {
+    binInput = document.querySelector(sel);
+    if (binInput) break;
+  }
+  for (const sel of voucherSelectors) {
+    voucherInput = document.querySelector(sel);
+    if (voucherInput) break;
+  }
+
+  if (!binInput || !voucherInput) {
+    document.body.setAttribute('data-validation-result', 'INVALID');
+    document.body.setAttribute('data-validation-message', 'FORM_NOT_FOUND');
+    return;
+  }
+
+  const typeHuman = async (el, value) => {
+    el.focus();
+    el.value = '';
+    for (let i = 0; i < value.length; i++) {
+      el.value += value[i];
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      await sleep(45);
+    }
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  };
+
+  await typeHuman(binInput, '${escJs(creditCard)}');
+  await typeHuman(voucherInput, '${escJs(voucherCode)}');
+  await sleep(300);
+
+  const btns = Array.from(document.querySelectorAll('button'));
+  const submitBtn =
+    document.querySelector('button[type="submit"], input[type="submit"]') ||
+    btns.find((b) => (b.textContent || '').trim().toLowerCase() === 'submit') ||
+    btns.find((b) => (b.textContent || '').trim().toLowerCase().includes('submit'));
+
+  if (submitBtn) submitBtn.click();
+  else {
+    document.body.setAttribute('data-validation-result', 'INVALID');
+    document.body.setAttribute('data-validation-message', 'SUBMIT_NOT_FOUND');
+    return;
+  }
+
+  for (let i = 0; i < 40; i++) {
+    await sleep(500);
+    const html = document.body ? document.body.innerHTML : '';
+    if (html.includes(USED)) {
+      document.body.setAttribute('data-validation-result', 'INVALID');
+      document.body.setAttribute('data-validation-message', USED);
+      return;
+    }
+    if (html.includes(BAD)) {
+      document.body.setAttribute('data-validation-result', 'INVALID');
+      document.body.setAttribute('data-validation-message', BAD);
+      return;
+    }
+    if (binInput.getAttribute('aria-invalid') === 'true' || voucherInput.getAttribute('aria-invalid') === 'true') {
+      document.body.setAttribute('data-validation-result', 'INVALID');
+      document.body.setAttribute('data-validation-message', 'FIELD_INVALID');
+      return;
+    }
+    const txt = document.body ? document.body.innerText : '';
+    if (/select a destination|choose your hotel|amex kfa/i.test(txt)) {
+      document.body.setAttribute('data-validation-result', 'VALID');
+      return;
+    }
+  }
+
+  document.body.setAttribute('data-validation-result', 'INVALID');
+  document.body.setAttribute('data-validation-message', 'TIMEOUT');
+})();
+`;
+}
+
+async function validateWithScraperApi(
+  creditCard: string,
+  voucherCode: string,
+  scraperApiKey: string,
+): Promise<VoucherValidationResult> {
+  const custom_js = buildScraperCustomJs(creditCard, voucherCode);
+  const params = new URLSearchParams({
+    api_key: scraperApiKey,
+    url: BASE_URL,
+    render: "true",
+    country_code: "sg",
+    premium: "true",
+    wait: "25000",
+    custom_js,
+  });
+
+  const url = `https://api.scraperapi.com/?${params.toString()}`;
+  const timeoutMs = 90000;
+  const response = await Promise.race([
+    fetch(url, {
+      method: "GET",
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      },
+    }),
+    new Promise<Response>((_, reject) =>
+      setTimeout(() => reject(new Error("ScraperAPI voucher request timeout")), timeoutMs)
+    ),
+  ]);
+
+  if (!response.ok) {
+    throw new Error(`ScraperAPI ${response.status}`);
+  }
+
+  const html = await response.text();
+  const parsed = parseVoucherOutcome(html);
+  if (parsed) return parsed;
+
+  if (html.includes(USED_VOUCHER_MSG)) {
+    return { valid: false, error: USED_VOUCHER_MSG };
+  }
+  if (html.includes(INCORRECT_ENTRY_MSG)) {
+    return {
+      valid: false,
+      error:
+        "We couldn't verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.",
+    };
+  }
+
+  if (html.includes('data-validation-message="FORM_NOT_FOUND"')) {
+    throw new Error("ScraperAPI: form not found in DOM");
+  }
+
+  return {
+    valid: false,
+    error: "Unable to verify voucher details at this time. Please try again.",
+  };
+}
+
+async function validateVoucher(
+  creditCard: string,
+  voucherCode: string,
+): Promise<VoucherValidationResult> {
+  console.log("Voucher validation for:", { creditCard, voucherCode });
+
+  const browserlessToken = Deno.env.get("BROWSERLESS_API_KEY");
+  const scraperApiKey = Deno.env.get("SCRAPERAPI_KEY");
+
+  if (!browserlessToken && !scraperApiKey) {
+    return {
+      valid: false,
+      error: "No scraping provider configured (BROWSERLESS_API_KEY and/or SCRAPERAPI_KEY).",
+    };
+  }
+
   if (!creditCard || creditCard.length !== 6) {
-    return {
-      valid: false,
-      error: 'Credit card number must be 6 digits'
-    };
+    return { valid: false, error: "Credit card number must be 6 digits" };
   }
-  
+
   if (!voucherCode || voucherCode.length !== 10) {
-    return {
-      valid: false,
-      error: 'Voucher code must be 10 characters'
-    };
+    return { valid: false, error: "Voucher code must be 10 characters" };
   }
-  
-  // Use Fast + Fallback approach like hotel availability function
-  const baseUrl = 'https://apac.hilton.com/amexkrisflyer';
-  
-  try {
-    console.log(`Fast checking voucher validation: ${creditCard} / ${voucherCode}`);
 
-    // Try FAST approach first - minimal JavaScript, quick validation
-    const fastParams = new URLSearchParams({
-      'api_key': scraperApiKey,
-      'url': baseUrl,
-      'render': 'true', // Need JavaScript for form interaction
-      'country_code': 'sg',
-      'premium': 'true',
-      'wait': '2000', // Short wait
-      'custom_js': `
-        // ChatGPT-inspired approach: human-like typing + proper event sequence
-        setTimeout(async () => {
-          console.log('Starting enhanced voucher validation...');
-          
-          // Try multiple selectors like ChatGPT suggested
-          const cardSelectors = ['input[name="bin_number"]', '#bin_number', 'input[autocomplete="cc-number"]', 'input[inputmode="numeric"]'];
-          const voucherSelectors = ['input[name="voucher_no"]', '#voucher_no', 'input[name="voucher"]', 'input[data-field="voucher"]'];
-          
-          let binInput = null;
-          let voucherInput = null;
-          
-          // Find inputs using multiple selectors
-          for (const sel of cardSelectors) {
-            binInput = document.querySelector(sel);
-            if (binInput) break;
-          }
-          for (const sel of voucherSelectors) {
-            voucherInput = document.querySelector(sel);
-            if (voucherInput) break;
-          }
-          
-          if (binInput && voucherInput) {
-            console.log('Found form inputs, filling with human-like typing...');
-            
-            // Fill card field with human-like typing
-            binInput.focus();
-            binInput.value = '';
-            const cardValue = '${creditCard}';
-            for (let i = 0; i < cardValue.length; i++) {
-              binInput.value += cardValue[i];
-              binInput.dispatchEvent(new Event('input', { bubbles: true }));
-              await new Promise(r => setTimeout(r, 50)); // 50ms delay between chars
-            }
-            binInput.dispatchEvent(new Event('change', { bubbles: true }));
-            
-            // Fill voucher field with human-like typing
-            voucherInput.focus();
-            voucherInput.value = '';
-            const voucherValue = '${voucherCode}';
-            for (let i = 0; i < voucherValue.length; i++) {
-              voucherInput.value += voucherValue[i];
-              voucherInput.dispatchEvent(new Event('input', { bubbles: true }));
-              await new Promise(r => setTimeout(r, 50)); // 50ms delay between chars
-            }
-            voucherInput.dispatchEvent(new Event('change', { bubbles: true }));
-            
-            // Trigger blur via Tab (simulates user behavior)
-            document.activeElement.blur();
-            
-            console.log('Form filled, waiting for validation (650ms debounce)...');
-            
-            // Wait for debounce like ChatGPT suggested
-            setTimeout(() => {
-              console.log('Checking validation results...');
-              
-              // Multi-signal validation detection like ChatGPT approach
-              const errorSelectors = [
-                '[role="alert"]',
-                '[aria-live="assertive"]',
-                '.invalid-feedback',
-                '.error',
-                '.has-error',
-                '[data-error-for="bin_number"]',
-                '[data-error-for="voucher_no"]'
-              ];
-              
-              let errorFound = false;
-              let errorDetails = [];
-              
-              // Check for visible error elements
-              errorSelectors.forEach(sel => {
-                const elements = document.querySelectorAll(sel);
-                elements.forEach(el => {
-                  const rect = el.getBoundingClientRect();
-                  const style = getComputedStyle(el);
-                  const isVisible = rect.width > 0 && rect.height > 0 && 
-                                  style.display !== 'none' && 
-                                  style.visibility !== 'hidden' && 
-                                  style.opacity !== '0';
-                  
-                  if (isVisible && el.textContent.trim()) {
-                    errorFound = true;
-                    errorDetails.push({
-                      selector: sel,
-                      text: el.textContent.trim()
-                    });
-                  }
-                });
-              });
-              
-              // Check ARIA invalid attributes
-              if (binInput.getAttribute('aria-invalid') === 'true' || 
-                  voucherInput.getAttribute('aria-invalid') === 'true') {
-                errorFound = true;
-                errorDetails.push({ type: 'aria-invalid', value: 'true' });
-              }
-              
-              // Check validity API
-              const cardValid = binInput.checkValidity ? binInput.checkValidity() : true;
-              const voucherValid = voucherInput.checkValidity ? voucherInput.checkValidity() : true;
-              
-              if (!cardValid || !voucherValid) {
-                errorFound = true;
-                errorDetails.push({ 
-                  type: 'validity-api', 
-                  cardValid, 
-                  voucherValid,
-                  cardMessage: binInput.validationMessage || '',
-                  voucherMessage: voucherInput.validationMessage || ''
-                });
-              }
-              
-              // Check for specific error text (your original approach)
-              const usedVoucherError = document.body.innerHTML.includes("You've used your voucher code. Please provide another one.");
-              if (usedVoucherError) {
-                errorFound = true;
-                errorDetails.push({ type: 'used-voucher', found: true });
-                document.body.setAttribute('data-validation-message', "You've used your voucher code. Please provide another one.");
-              }
-
-              const specificError = document.body.innerHTML.includes("You've provided an incorrect entry. Please try again.");
-              if (specificError) {
-                errorFound = true;
-                errorDetails.push({ type: 'specific-error-text', found: true });
-                document.body.setAttribute('data-validation-message', "You've provided an incorrect entry. Please try again.");
-              }
-
-              // Click submit if present (matches real user flow)
-              try {
-                const btns = Array.from(document.querySelectorAll('button'));
-                const submitBtn = document.querySelector('button[type=\"submit\"], input[type=\"submit\"]') ||
-                  btns.find(b => (b.textContent || '').trim().toLowerCase() === 'submit') ||
-                  btns.find(b => (b.textContent || '').trim().toLowerCase().includes('submit'));
-                if (submitBtn) {
-                  submitBtn.click();
-                }
-              } catch (e) {}
-              
-              // Set result marker
-              if (errorFound) {
-                document.body.setAttribute('data-validation-result', 'INVALID');
-                document.body.setAttribute('data-error-details', JSON.stringify(errorDetails));
-                console.log('Validation FAILED - errors detected:', errorDetails);
-              } else {
-                document.body.setAttribute('data-validation-result', 'VALID');
-                console.log('Validation SUCCESS - no errors detected');
-              }
-            }, 650); // ChatGPT's recommended debounce time
-            
-          } else {
-            console.log('Could not find form inputs');
-            document.body.setAttribute('data-validation-result', 'FORM_NOT_FOUND');
-          }
-        }, 1000);
-      `
-    });
-
-    const fastScraperUrl = `https://api.scraperapi.com/?${fastParams.toString()}`;
-    
-    // Short timeout for fast approach
-    const timeoutMs = 10000; // 10 seconds only
-    const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('Fast voucher validation timeout')), timeoutMs);
-    });
-
-    const startTime = Date.now();
-    const response = await Promise.race([
-      fetch(fastScraperUrl, {
-        method: 'GET',
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-        }
-      }),
-      timeoutPromise
-    ]) as Response;
-
-    const duration = Date.now() - startTime;
-    console.log(`${creditCard} fast voucher validation: ${response.status} (${duration}ms)`);
-
-    if (response.ok) {
-      const html = await response.text();
-      console.log(`${creditCard} fast HTML length: ${html.length}`);
-
-      // Check the enhanced validation result
-      if (html.includes('data-validation-result="INVALID"')) {
-        console.log(`${creditCard} FAST INVALID: Enhanced validation detected errors`);
-
-        // Prefer returning the exact on-page message if we captured it.
-        const msgMatch = html.match(/data-validation-message="([^"]+)"/);
-        if (msgMatch) {
-          const msg = msgMatch[1].replace(/&quot;/g, '"');
-          return { valid: false, error: msg };
-        }
-        
-        // Extract error details if available
-        const errorDetailsMatch = html.match(/data-error-details="([^"]+)"/);
-        let errorInfo = '';
-        if (errorDetailsMatch) {
-          try {
-            const details = JSON.parse(errorDetailsMatch[1].replace(/&quot;/g, '"'));
-            errorInfo = ' - ' + details.map(d => d.text || d.type).join(', ');
-          } catch (e) {
-            // Ignore parsing errors
-          }
-        }
-        
-        return {
-          valid: false,
-          error: 'We couldn\'t verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.'
-        };
-      } else if (html.includes('data-validation-result="VALID"')) {
-        console.log(`${creditCard} FAST SUCCESS: Enhanced validation confirmed valid`);
-        return { valid: true };
-      }
-      
-      // Fallback to simple checks if enhanced validation didn't complete
-      const hasUsedVoucherError = html.includes("You've used your voucher code. Please provide another one.");
-      const hasSpecificError = html.includes("You've provided an incorrect entry. Please try again.");
-      const hasErrorClass = html.includes('class="error"') || html.includes('class="invalid"');
-      const hasAriaInvalid = html.includes('aria-invalid="true"');
-      
-      if (hasUsedVoucherError) {
-        console.log(`${creditCard} FAST INVALID: used voucher message found`);
-        return { valid: false, error: "You've used your voucher code. Please provide another one." };
-      }
-
-      if (hasSpecificError || hasErrorClass || hasAriaInvalid) {
-        console.log(`${creditCard} FAST INVALID: Basic error indicators found`);
-        return {
-          valid: false,
-          error: 'We couldn\'t verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.'
-        };
-      }
-      
-      console.log(`${creditCard} fast result incomplete, falling back to JS rendering`);
+  if (browserlessToken) {
+    try {
+      return await validateWithBrowserless(creditCard, voucherCode, browserlessToken);
+    } catch (e) {
+      console.log("Browserless voucher validation failed:", e?.message ?? e);
     }
-
-    // Fallback to longer JavaScript rendering if fast approach failed
-    console.log(`${creditCard} trying JS rendering fallback`);
-    
-    const jsParams = new URLSearchParams({
-      'api_key': scraperApiKey,
-      'url': baseUrl,
-      'render': 'true',
-      'country_code': 'sg',
-      'premium': 'true',
-      'wait': '4000', // Longer wait for fallback
-      'custom_js': `
-        setTimeout(() => {
-          // Simplified fallback version of ChatGPT approach
-          const cardSelectors = ['input[name="bin_number"]', '#bin_number', 'input[autocomplete="cc-number"]'];
-          const voucherSelectors = ['input[name="voucher_no"]', '#voucher_no', 'input[name="voucher"]'];
-          
-          let binInput = null;
-          let voucherInput = null;
-          
-          for (const sel of cardSelectors) {
-            binInput = document.querySelector(sel);
-            if (binInput) break;
-          }
-          for (const sel of voucherSelectors) {
-            voucherInput = document.querySelector(sel);
-            if (voucherInput) break;
-          }
-          
-          if (binInput && voucherInput) {
-            binInput.focus();
-            binInput.value = '${creditCard}';
-            binInput.dispatchEvent(new Event('input', { bubbles: true }));
-            binInput.dispatchEvent(new Event('change', { bubbles: true }));
-            binInput.blur();
-            
-            voucherInput.focus();
-            voucherInput.value = '${voucherCode}';
-            voucherInput.dispatchEvent(new Event('input', { bubbles: true }));
-            voucherInput.dispatchEvent(new Event('change', { bubbles: true }));
-            voucherInput.blur();
-            
-            // Wait for validation like ChatGPT suggested
-            setTimeout(() => {
-              const hasError = document.body.innerHTML.includes("You've provided an incorrect entry. Please try again.") ||
-                             binInput.getAttribute('aria-invalid') === 'true' ||
-                             voucherInput.getAttribute('aria-invalid') === 'true' ||
-                             document.querySelector('.error, .invalid, [role="alert"]');
-                             
-              if (hasError) {
-                document.body.setAttribute('data-validation-result', 'INVALID');
-              } else {
-                document.body.setAttribute('data-validation-result', 'VALID');
-              }
-            }, 650);
-          }
-        }, 1000);
-      `
-    });
-
-    const jsScraperUrl = `https://api.scraperapi.com/?${jsParams.toString()}`;
-    const jsTimeoutMs = 15000; // 15 seconds for JS version
-    const jsTimeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('JS voucher validation timeout')), jsTimeoutMs);
-    });
-
-    const jsStartTime = Date.now();
-    const jsResponse = await Promise.race([
-      fetch(jsScraperUrl, {
-        method: 'GET',
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-        }
-      }),
-      jsTimeoutPromise
-    ]) as Response;
-
-    const jsDuration = Date.now() - jsStartTime;
-    console.log(`${creditCard} JS voucher validation: ${jsResponse.status} (${jsDuration}ms)`);
-
-    if (!jsResponse.ok) {
-      throw new Error(`JS voucher validation failed: ${jsResponse.status}`);
-    }
-
-    const jsHtml = await jsResponse.text();
-    
-    // Check enhanced validation result from fallback
-    if (jsHtml.includes('data-validation-result="INVALID"')) {
-      console.log(`${creditCard} JS INVALID: Fallback validation detected errors`);
-      return {
-        valid: false,
-        error: 'We couldn\'t verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.'
-      };
-    } else if (jsHtml.includes('data-validation-result="VALID"')) {
-      console.log(`${creditCard} JS SUCCESS: Fallback validation confirmed valid`);
-      return { valid: true };
-    } else {
-      // Final fallback to simple error detection
-      const hasSpecificError = jsHtml.includes("You've provided an incorrect entry. Please try again.");
-      
-      if (hasSpecificError) {
-        console.log(`${creditCard} JS INVALID: Found specific error message`);
-        return {
-          valid: false,
-          error: 'We couldn\'t verify your voucher details. Please check your information and try again. If the problem continues, contact Vibez Ventures.'
-        };
-      } else {
-        console.log(`${creditCard} JS SUCCESS: No error indicators found`);
-        return { valid: true };
-      }
-    }
-
-  } catch (error) {
-    console.log('Voucher validation error:', error.message);
-    return {
-      valid: false,
-      error: 'Unable to verify voucher details at this time. Please try again.'
-    };
   }
+
+  if (scraperApiKey) {
+    try {
+      return await validateWithScraperApi(creditCard, voucherCode, scraperApiKey);
+    } catch (e) {
+      console.log("ScraperAPI voucher validation failed:", e?.message ?? e);
+    }
+  }
+
+  return {
+    valid: false,
+    error: "Unable to verify voucher details at this time. Please try again.",
+  };
 }
 
 serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
     const requestData: VoucherValidationRequest = await req.json();
-    console.log('Validating voucher:', requestData);
+    console.log("Validating voucher:", requestData);
 
     const result = await validateVoucher(requestData.creditCard, requestData.voucherCode);
-    
-    return new Response(JSON.stringify({
-      success: true,
-      valid: result.valid,
-      error: result.error
-    }), {
-      status: 200,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
 
+    return new Response(
+      JSON.stringify({
+        success: true,
+        valid: result.valid,
+        error: result.error,
+      }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   } catch (error) {
-    console.error('Error in validate-voucher function:', error);
-    return new Response(JSON.stringify({
-      success: false,
-      valid: false,
-      error: error.message
-    }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    console.error("Error in validate-voucher function:", error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        valid: false,
+        error: error.message,
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Edge functions**: Reworked `validate-voucher` to prefer Browserless (submit + wait for outcome), with a ScraperAPI path that uses async `custom_js` so the snapshot includes post-submit HTML. Updated `fetch-hotel-data` to fall back to Browserless when ScraperAPI returns thin HTML, and return `{ html }` from the Browserless script for consistent parsing. Updated `check-hotel-availability` with inlined date helpers and a simpler Browserless wait condition.
- **CI**: Added `workflow_dispatch` and runs on `cursor/**` pushes so integration tests can run on agent branches.
- **Frontend**: Removed Lovable-specific Open Graph / Twitter meta tags from `index.html`.

## Blockers / follow-up

- **GitHub Actions** still fails deploy with `401 Unauthorized` from Supabase CLI — the `SUPABASE_ACCESS_TOKEN` repository secret appears invalid or expired. Replace it with a current personal access token from the Supabase dashboard (Account → Access Tokens), then re-run the workflow.
- The **`web-scraping-and-browser-automation`** folder was not present in this workspace; add those markdown files to the repo if you want them reviewed in-tree.

## Verification

- `npm run build` passes locally.
- Headless Chrome against `vite preview` loads the app shell (title and bundle present). Full E2E against Hilton requires deployed edge functions with valid secrets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71c1adfe-c4cf-47e4-b6cf-da77d4aed82e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71c1adfe-c4cf-47e4-b6cf-da77d4aed82e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

